### PR TITLE
Create python site-packages folder according to the python version

### DIFF
--- a/install
+++ b/install
@@ -123,7 +123,7 @@ do_install()
     brew install python@3.8
     brew link python@3.8
 
-    mkdir -p ~/Library/Python/2.8/lib/python/site-packages
+    mkdir -p ~/Library/Python/3.8/lib/python/site-packages
     echo "$(brew --prefix)/lib/python3.8/site-packages" >> ~/Library/Python/3.8/lib/python/site-packages/homebrew.pth
   fi
   # export PATH="/usr/local/opt/python@3.8/bin:$PATH"


### PR DESCRIPTION
Hello Steve Nogar

First, thank you for updating this repository and providing a script to install ROS on macOS Big Sur.

Second, I found few points where we should update the current script. They are small fixes, but I believe it is important to keep this script up to date.

------

The fix on this pull request is just a small typing error. Normally it does not cause any issue, but if you get a fresh new macOS, as I am testing here on this machine, it will complain saying that the folder `~/Library/Python/3.8/` does not exist.

I hope it will be helpful to some else in the future.

Kind regards